### PR TITLE
l10n: ca: consistently translate "graph" as "graf"

### DIFF
--- a/po/ca.po
+++ b/po/ca.po
@@ -20,6 +20,7 @@
 #   fatal            |  fatal
 #   fetch            |  obtenir
 #   flush            |  buidar / buidatge
+#   graph            |  graf
 #   hint             |  consell
 #   hook             |  lligam
 #   hunk             |  tros
@@ -2474,7 +2475,7 @@ msgstr ""
 #: commit-graph.c:2504
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
-msgstr "el gràfic de comissions té una ordre OID incorrecta; %s llavors %s"
+msgstr "el graf de comissions té una ordre OID incorrecta; %s llavors %s"
 
 #: commit-graph.c:2514 commit-graph.c:2529
 #, c-format


### PR DESCRIPTION
Segons [dlc.iec.cat](https://dlc.iec.cat/), «graf» vol dir «Conjunt format per vèrtexs units per camins o arestes», mentre «gràfic» vol dir «Representació per mitjà del dibuix». De les dues paraules, em sembla que *graf* és més adequada, i ja era el termini més comú en la traducció del Git.